### PR TITLE
Results page but mobile

### DIFF
--- a/src/components/result/result.tsx
+++ b/src/components/result/result.tsx
@@ -54,7 +54,7 @@ export default function Result({ score }: ResultProps) {
     <div className="font-inter flex flex-col items-center justify-center">
       {/* Screenshot target container */}
       <div id="result-screenshot" className="py-8">
-        <div className="flex">
+        <div className="flex flex-col items-center md:flex-row">
           <Image src={riceImage} alt="sad Rice" width={300} height={300} />
 
           <div className="flex flex-col items-center justify-center">


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4b5815b1-292a-468c-ae96-c0e01a9e8c9b)

----------------

### How the screenshot looks on mobile
![ucr-purity-score-25](https://github.com/user-attachments/assets/18fd33d8-3a2f-48c7-a5ea-513e4977be07)
