### PR TITLE
fixed spacing between names and icon

### DIFF
--- a/src/components/board/boardCard.tsx
+++ b/src/components/board/boardCard.tsx
@@ -21,9 +21,9 @@ const BoardCard = ({ linkedin, name, image }: BoardProps) => {
           className="h-full w-full rounded-2xl object-cover"
         />
       </div>
-      <div className="text-purity-blue-200 m-2 flex items-center text-center text-base font-semibold md:text-xl">
+      <div className="text-purity-blue-200 m-2 flex items-center text-center text-sm font-semibold md:text-xl">
         <p>{name}</p>
-        <p className="ml-3 hover:text-black">
+        <p className="ml-2 hover:text-black">
           <Link href={linkedin}>
             <FaLinkedin />
           </Link>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b253eba0-e37f-4e33-8de4-32adef4393f2)
![image](https://github.com/user-attachments/assets/c8710dda-cf1e-4d6d-a471-265e87c0b5e7)
![image](https://github.com/user-attachments/assets/1897be7c-ba7d-499e-a476-5dbac389053d)

- fixed spacing between names and Linkedin icon on smaller phones screens